### PR TITLE
correct formatting issue in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,12 +2,14 @@ MBUILD USER INFO
 -----------------
   See:
      
-      https://intelxed.github.io/
-and 
-      https://github.com/intelxed/mbuild
+https://intelxed.github.io/
+
+and
+
+https://github.com/intelxed/mbuild
 
 Documentation generation manual:
-    http://epydoc.sourceforge.net/epydoc.html
+http://epydoc.sourceforge.net/epydoc.html
 
 To generate documentation from a check'ed out source tree, see "build-doc"
    


### PR DESCRIPTION
4 spaces can be formated as code in markdown