### PR TITLE
Changed regex string to raw String. Python3.12 gave a SyntaxWarning on this line

### DIFF
--- a/mbuild/util.py
+++ b/mbuild/util.py
@@ -928,7 +928,7 @@ def get_clang_version(full_path):
         (retcode, stdout, stderr) = run_command(f'{full_path} --version')
         if retcode == 0:
             for line in stdout:
-                r = re.search('version[ ]+(?P<version>(\d+\.)+\d+)', line.lower())
+                r = re.search(r'version[ ]+(?P<version>(\d+\.)+\d+)', line.lower())
                 if r:
                     return r.group('version')
     except:


### PR DESCRIPTION
Python 3.12.3 now reports a syntax warning on line 931 of mbuild/util.py. Changing the string to a raw string fixes the issue.