### PR TITLE
External Release v2024.09.08

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 *~
 *#
 .#*
+build/
+*.egg-info/

--- a/mbuild/build_env.py
+++ b/mbuild/build_env.py
@@ -2,7 +2,7 @@
 # -*- python -*-
 #BEGIN_LEGAL
 #
-#Copyright (c) 2023 Intel Corporation
+#Copyright (c) 2024 Intel Corporation
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.
@@ -40,10 +40,11 @@ def set_compiler_env_common(env):
     env['debug_flag_link'] = ( 'debug', { True: '%(DEBUGFLAG_LINK)s',
                                           False:''})
 
-    win_shared_compile_dict = ( 'compiler', { 'ms': ( 'debug', { True: '/MDd', False: '/MD' }),
-                                              'icl': ( 'debug', { True: '/MDd', False: '/MD' }), 
-                                              'otherwise': '',
-                                              })
+    win_shared_compile_dict = ('compiler', 
+                                            {'ms': ('mbuild_mscrt', {False: '', True: ('debug', {True: '/MDd', False: '/MD'})}),
+                                             'icl': ('mbuild_mscrt', {False: '', True: ('debug', {True: '/MDd', False: '/MD'})}),
+                                            'otherwise': '',
+                                            })
 
     shared_compile_dict = ( 'host_os', { 'android': '-fPIC',
                                           'lin': '-fPIC',
@@ -52,8 +53,9 @@ def set_compiler_env_common(env):
                                           'otherwise': '',
                                           })
     
-    win_static_compile_dict = ( 'compiler', { 'ms': ( 'debug', { True: '/MTd', False: '/MT' }),
-                                              'icl': ( 'debug', { True: '/MTd', False: '/MT' }), 
+    win_static_compile_dict = ( 'compiler', 
+                                            {'ms': ('mbuild_mscrt', {False: '', True: ('debug', {True: '/MTd', False: '/MT'})}),
+                                            'icl': ('mbuild_mscrt', {False: '', True: ('debug', {True: '/MTd', False: '/MT'})}),
                                               'otherwise': '',
                                               })
 

--- a/mbuild/env.py
+++ b/mbuild/env.py
@@ -94,6 +94,7 @@ class env_t(object):
           - icc_version    7, 8, 9, 10, ...
           - gcc_version    2.96, 3.x.y, 4.x.y, ...
           - msvs_version   6 (VC98), 7 (.NET 2003), 8 (Pro 2005), ...
+          - no_mscrt       No implicit MSVC CRT-library build knob (/MT[d], /MD[d])
           
           - primary compilation toolsE{:}
              - CC             cl or gcc          (with toolchain path)
@@ -555,6 +556,7 @@ class env_t(object):
             vc_dir='',
             msvs_version='',
             setup_msvc=False,
+            mbuild_mscrt=True,
             icc_version='',
             gcc_version='',
             cc='',
@@ -718,6 +720,12 @@ class env_t(object):
             action='store_true',
             help="Use the value of the --msvc-version to initialize" +
             " the MSVC configuration.")
+        self.parser.add_option(
+            "--no-mscrt",
+            dest="mbuild_mscrt",
+            action="store_false",
+            help="No implicit MSVC CRT-library build knob (/MT[d], /MD[d])"
+            )
         self.parser.add_option(
             '--icc-version',
             '--iccver',

--- a/mbuild/util.py
+++ b/mbuild/util.py
@@ -7,14 +7,14 @@
 #  you may not use this file except in compliance with the License.
 #  You may obtain a copy of the License at
 #
-#        http://www.apache.org/licenses/LICENSE-2.0
+#      http://www.apache.org/licenses/LICENSE-2.0
 #
 #  Unless required by applicable law or agreed to in writing, software
 #  distributed under the License is distributed on an "AS IS" BASIS,
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
-#
+#  
 #END_LEGAL
 
 """Basic useful utilities: file copying, removal, permissions,
@@ -99,12 +99,12 @@ def copy_tree(src,tgt, ignore_patterns=None, symlinks=False):
     if verbose(2):
         msgb("Done copying tree", tgt)
 
-def cmkdir(path_to_dir):
+def cmkdir(path_to_dir, exist_ok = False):
     """Make a directory if it does not exist"""
     if not os.path.exists(path_to_dir):
         if verbose(2):
             msgb("MKDIR", path_to_dir)
-        os.makedirs(path_to_dir)
+        os.makedirs(path_to_dir,exist_ok=exist_ok)
 def list2string(ls):
     """Print a list as a string"""
     s = " ".join(ls)
@@ -928,7 +928,7 @@ def get_clang_version(full_path):
         (retcode, stdout, stderr) = run_command(f'{full_path} --version')
         if retcode == 0:
             for line in stdout:
-                r = re.search('version[ ]+(?P<version>(\d+\.)+\d+)', line.lower())
+                r = re.search(r'version[ ]+(?P<version>(\d+\.)+\d+)', line.lower())
                 if r:
                     return r.group('version')
     except:


### PR DESCRIPTION
- Fix Python 3.12 warning (resolves intelxed/mbuild#52)
- Extend MSVC CRT build control to allow CRT library exclusion.
- Enhance `cmkdir()` Python wrapper by adding the `exist_ok` option.
- Update `.gitignore` file (resolves intelxed/mbuild#48)