### PR TITLE
External Release v2024.11.04

### DIFF
--- a/mbuild/base.py
+++ b/mbuild/base.py
@@ -165,10 +165,10 @@ def check_python_version(maj,minor,fix=0):
 
 
 try:
-  if check_python_version(3,8) == False:
-    die("MBUILD error: Need Python version 3.8 or later.")
+  if check_python_version(3,9) == False:
+    die("MBUILD error: Need Python version 3.9 or later.")
 except:
-  die("MBUILD error: Need Python version 3.8 or later.")
+  die("MBUILD error: Need Python version 3.9 or later.")
 
 import platform
 _on_mac = False

--- a/mbuild/build_env.py
+++ b/mbuild/build_env.py
@@ -201,7 +201,7 @@ def set_env_gnu(env):
     env['LIBOUT'] = ' ' # nothing when using gar/ar
     env['LINKOUT'] = '-o '
     env['EXEOUT'] = '-o '
-    if env.on_mac():
+    if env.on_mac() or env.on_windows():
         env['DLLOPT'] = '-shared' # '-dynamiclib'
     else:
         env['DLLOPT'] = '-shared -Wl,-soname,%(SOLIBNAME)s'

--- a/mbuild/env.py
+++ b/mbuild/env.py
@@ -452,8 +452,8 @@ class env_t(object):
         distro = ''
         distro_ver = ''
         if  not self.on_mac()  and   not self.on_windows():
-            if util.check_python_version(3,8):
-                # With python 3.8 one needs to install the python "distro"
+            if util.check_python_version(3,9):
+                # With python 3.9 one needs to install the python "distro"
                 # package to obtain the linux distro information. I do not
                 # want to require users to install a non-default package
                 # so we'll have to live without the distro information.


### PR DESCRIPTION
- Fix issue with Clang on Windows for shared library builds.
- Update minimum Python requirement from 3.8 to 3.9.