### PR TITLE
Convert string to raw-string, as backslash is interpreted as an escape character

### DIFF
--- a/mbuild/build_env.py
+++ b/mbuild/build_env.py
@@ -291,7 +291,7 @@ def _check_set_rc(env, sdk):
 
 
 def _find_rc_cmd(env):
-    """Finding the rc executable is a bit of a nightmare.
+    r"""Finding the rc executable is a bit of a nightmare.
     
      In MSVS2005(VC8):
          C:/Program Files (x86)/Microsoft Visual Studio 8/VC


### PR DESCRIPTION
Python 3.12 interprets the backslash as an escape character. Converting the string to a raw-string avoids this.