### PR TITLE
External Release v2026.05.19

### DIFF
--- a/mbuild/build_env.py
+++ b/mbuild/build_env.py
@@ -227,7 +227,7 @@ def find_ms_toolchain(env):
     if env['msvs_version']:
         env['setup_msvc']=True
 
-    if env['vc_dir'] == '' and not env['setup_msvc']:
+    if not env['setup_msvc']:
         if 'MSVCDir' in os.environ:
             vs_dir = os.environ['MSVCDir']
             if os.path.exists(vs_dir):

--- a/mbuild/env.py
+++ b/mbuild/env.py
@@ -90,7 +90,9 @@ class env_t(object):
   
           - toolchain      path to the compiler tools (default is ''). If toolchain is
                            set, it should end with a trailing slash.
-          - vc_dir         path to the compiler VC directory for MSVS (default is '')n
+          - toolchain_vs   Visual Studio installation directory including edition
+                           (for example .../2022/Professional) for MSVS setup
+                           override (default is '')
           - icc_version    7, 8, 9, 10, ...
           - gcc_version    2.96, 3.x.y, 4.x.y, ...
           - msvs_version   6 (VC98), 7 (.NET 2003), 8 (Pro 2005), ...
@@ -551,9 +553,10 @@ class env_t(object):
             extra_linkflags=[],
             extra_libs=[],
             toolchain='',
+            vc_dir='',
+            toolchain_vs='',
             ignorable_files=[], # deprecated, unused 2011-10-20
             required_files=[],
-            vc_dir='',
             msvs_version='',
             setup_msvc=False,
             mbuild_mscrt=True,
@@ -695,11 +698,12 @@ class env_t(object):
             action="store",
             help="Compiler toolchain")
         self.parser.add_option(
-            "--vc-dir",
-            dest="vc_dir",
+            "--toolchain-vs",
+            dest="toolchain_vs",
             action="store",
-            help="MSVS Compiler VC directory. For finding libraries " + 
-            " and setting the toolchain")
+            help="Visual Studio root directory for MSVS setup override. " +
+            "For MSVS 2017 and newer, include the edition " +
+            "(e.g. .../Microsoft Visual Studio/2022/Professional). ")
         self.parser.add_option(
             '--msvs-version',
             '--msvc-version',
@@ -973,6 +977,12 @@ class env_t(object):
             sys.exit(0)
 
         self._implied_compiler(self.env)
+
+        if self.env['toolchain_vs']:
+            if self.env['compiler'] != 'ms' or not self.env['msvs_version']:
+                die("--toolchain-vs requires --compiler=ms and --msvs-version")
+            if self.env['toolchain']:
+                die("--toolchain and --toolchain-vs are mutually exclusive")
 
         if self.env['silent']:
             set_verbosity(0)

--- a/mbuild/msvs.py
+++ b/mbuild/msvs.py
@@ -150,7 +150,7 @@ def _set_msvs_dev8(env, x64_host, x64_target, regv=None): # VS 2005
     else:
         prefixes = ["c:/Program Files (x86)/Microsoft Visual Studio 8",
                     "c:/Program Files/Microsoft Visual Studio 8"]
-    prefix = _find_dir_list(prefixes)
+        prefix = _find_dir_list(prefixes)
     if not os.path.exists(prefix):
         die("Could not find MSVC8 (2005)")
 
@@ -224,7 +224,7 @@ def _set_msvs_dev9(env, x64_host, x64_target, regv=None): # VS 2008
     else:
         prefixes = ['C:/Program Files (x86)/Microsoft Visual Studio 9.0',
                     'C:/Program Files/Microsoft Visual Studio 9.0']
-    prefix = _find_dir_list(prefixes)
+        prefix = _find_dir_list(prefixes)
 
     set_env('VSINSTALLDIR', prefix)
     set_env('VS90COMNTOOLS', prefix + '/Common7/Tools')
@@ -695,23 +695,20 @@ def _set_msvs_dev18(env, x64_host, x64_target, regv=None): # msvs 2026
     
     progfi = 'C:/Program Files (x86)'
     if regv:
-        prefix = regv
+        p = regv
     else:
         prefix = 'C:/Program Files/Microsoft Visual Studio/2026'
+        for v in versions:
+            p = _ijoin(prefix, v)
+            if os.path.exists(p):
+                break
+    if not os.path.exists(p):
+        die('Could not find MSVS 2026 directory')
 
     if x64_target:
         tgt = 'x64'
     else:
         tgt = 'x86'
-
-    found = False
-    for v in versions:
-        p = _ijoin(prefix,v)
-        if os.path.exists(p):
-            found = True
-            break
-    if not found:
-        die('Could not find MSVS 2026 directory')
     vprefix = p
     winkit10 = progfi + '/Windows Kits/10'    
     winkit10version, winkit10complete = _get_winkit10_version(env,winkit10)
@@ -870,23 +867,20 @@ def _set_msvs_dev17(env, x64_host, x64_target, regv=None): # msvs 2022
     
     progfi = 'C:/Program Files (x86)'
     if regv:
-        prefix = regv
+        p = regv
     else:
         prefix = 'C:/Program Files/Microsoft Visual Studio/2022'
+        for v in versions:
+            p = _ijoin(prefix, v)
+            if os.path.exists(p):
+                break
+    if not os.path.exists(p):
+        die('Could not find MSVS 2022 directory')
 
     if x64_target:
         tgt = 'x64'
     else:
         tgt = 'x86'
-
-    found = False
-    for v in versions:
-        p = _ijoin(prefix,v)
-        if os.path.exists(p):
-            found = True
-            break
-    if not found:
-        die('Could not find MSVS 2022 directory')
     vprefix = p
     winkit10 = progfi + '/Windows Kits/10'    
     winkit10version, winkit10complete = _get_winkit10_version(env,winkit10)
@@ -905,7 +899,7 @@ def _set_msvs_dev17(env, x64_host, x64_target, regv=None): # msvs 2022
     libpath = []
     inc  = []
     
-    add_env(inc, prefix + '/ATLMFC/include')
+    add_env(inc, msvc_tools_root + '/ATLMFC/include')
     add_env(inc, msvc_tools_root + '/include')
     add_env(inc, netfx_sdk + 'include/um')
     wki = '{}/include/{}'.format(winkit10, winkit10version)
@@ -1051,23 +1045,20 @@ def _set_msvs_dev16(env, x64_host, x64_target, regv=None): # msvs 2019
     
     progfi = 'C:/Program Files (x86)'
     if regv:
-        prefix = regv
+        p = regv
     else:
         prefix = progfi + '/Microsoft Visual Studio/2019'
+        for v in versions:
+            p = _ijoin(prefix, v)
+            if os.path.exists(p):
+                break
+    if not os.path.exists(p):
+        die('Could not find MSVS 2019 directory')
 
     if x64_target:
         tgt = 'x64'
     else:
         tgt = 'x86'
-
-    found = False
-    for v in versions:
-        p = _ijoin(prefix,v)
-        if os.path.exists(p):
-            found = True
-            break
-    if not found:
-        die('Could not find MSVS 2019 directory')
     vprefix = p
     winkit10 = progfi + '/Windows Kits/10'    
     winkit10version, winkit10complete = _get_winkit10_version(env,winkit10)
@@ -1086,7 +1077,7 @@ def _set_msvs_dev16(env, x64_host, x64_target, regv=None): # msvs 2019
     libpath = []
     inc  = []
     
-    add_env(inc, prefix + '/ATLMFC/include')
+    add_env(inc, msvc_tools_root + '/ATLMFC/include')
     add_env(inc, msvc_tools_root + '/include')
     add_env(inc, netfx_sdk + 'include/um')
     wki = '{}/include/{}'.format(winkit10, winkit10version)
@@ -1233,23 +1224,20 @@ def _set_msvs_dev15(env, x64_host, x64_target, regv=None): # msvs 2017
     
     progfi = 'C:/Program Files (x86)'
     if regv:
-        prefix = regv
+        p = regv
     else:
         prefix = progfi + '/Microsoft Visual Studio/2017'
+        for v in versions:
+            p = _ijoin(prefix, v)
+            if os.path.exists(p):
+                break
+    if not os.path.exists(p):
+        die('Could not find MSVS 2017 directory')
 
     if x64_target:
         tgt = 'x64'
     else:
         tgt = 'x86'
-
-    found = False
-    for v in versions:
-        p = _ijoin(prefix,v)
-        if os.path.exists(p):
-            found = True
-            break
-    if not found:
-        die('Could not find MSVS 2017 directory')
     vprefix = p
     #msgb('VPREFIX', vprefix)
     winkit10 = progfi + '/Windows Kits/10'    
@@ -1269,7 +1257,7 @@ def _set_msvs_dev15(env, x64_host, x64_target, regv=None): # msvs 2017
     libpath = []
     inc  = []
     
-    add_env(inc, prefix + '/ATLMFC/include')
+    add_env(inc, msvc_tools_root + '/ATLMFC/include')
     add_env(inc, msvc_tools_root + '/include')
     add_env(inc, netfx_sdk + 'include/um')
     wki = '{}/include/{}'.format(winkit10, winkit10version)
@@ -1743,6 +1731,7 @@ def _find_specific_msvs_version(env,uv):
 
         
 def set_msvs_env(env):
+
     versions = []
     if env['msvs_version'] != '' :
         if ',' in env['msvs_version']:    # got a list of versions
@@ -1788,6 +1777,11 @@ def set_msvs_env(env):
     # "express" compiler is 32b only            
     vc = None
     vs_dir = None
+    if env['toolchain_vs']:
+        vs_dir = env['toolchain_vs']
+        if not os.path.exists(vs_dir):
+            die("--toolchain-vs path does not exist: " + vs_dir)
+
     i = int(env['msvs_version'])
     if i == 6: # 32b only
         vc = _set_msvs_dev6(env,x64_host, x64_target)


### PR DESCRIPTION
Improved Windows Visual Studio toolchain selection by replacing the obsolete `--vc-dir` build option with a working `--toolchain-vs` option for selecting a custom Visual Studio installation root directory (`--msvs-version` required).
(Closes intelxed/mbuild#63)